### PR TITLE
Dev/65:  Docker judger exited container auto-removal

### DIFF
--- a/Judger/src/main/java/tw/waterball/judgegirl/judger/Main.java
+++ b/Judger/src/main/java/tw/waterball/judgegirl/judger/Main.java
@@ -36,6 +36,7 @@ public class Main {
         logger.info("CCJudger has been instantiated.");
         judger.judge(values.studentId, values.problemId, values.submissionId);
         logger.info("CCJudger has completed the judge.");
+        System.exit(0);
     }
 
 }

--- a/Plugins/src/main/java/tw/waterball/judgegirl/plugins/impl/match/AllMatchPolicyPlugin.java
+++ b/Plugins/src/main/java/tw/waterball/judgegirl/plugins/impl/match/AllMatchPolicyPlugin.java
@@ -72,6 +72,5 @@ public class AllMatchPolicyPlugin extends AbstractJudgeGirlMatchPolicyPlugin {
         String actual = IOUtils.toString(new FileInputStream(actualFilePath.toFile()), StandardCharsets.US_ASCII);
         String expected = IOUtils.toString(new FileInputStream(expectFilePath.toFile()), StandardCharsets.US_ASCII);
         return actual.equals(expected);
-
     }
 }


### PR DESCRIPTION
# Description

See the linked issues for the details.

## Changes

- `System.exit(0)` when judger ends up (otherwise it might keep its connection with rabbitmq)
- Use `ScheduledExecutorService` to remove the exited judger container in intervals