### PR TITLE
Dev/111 [PATCH] /api/problems

### DIFF
--- a/Entities/src/main/java/tw/waterball/judgegirl/entities/problem/Problem.java
+++ b/Entities/src/main/java/tw/waterball/judgegirl/entities/problem/Problem.java
@@ -100,8 +100,8 @@ public class Problem {
         return filterPluginTags;
     }
 
-    public void setFilterPluginTags(Set<JudgePluginTag> filterPluginTags) {
-        this.filterPluginTags = filterPluginTags;
+    public void setFilterPluginTags(Collection<JudgePluginTag> filterPluginTags) {
+        this.filterPluginTags = new HashSet<>(filterPluginTags);
     }
 
     public List<String> getTags() {

--- a/Entities/src/main/java/tw/waterball/judgegirl/entities/problem/Problem.java
+++ b/Entities/src/main/java/tw/waterball/judgegirl/entities/problem/Problem.java
@@ -100,6 +100,10 @@ public class Problem {
         return filterPluginTags;
     }
 
+    public void setFilterPluginTags(Set<JudgePluginTag> filterPluginTags) {
+        this.filterPluginTags = filterPluginTags;
+    }
+
     public List<String> getTags() {
         return tags;
     }

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/repositories/PatchProblemParams.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/repositories/PatchProblemParams.java
@@ -4,8 +4,8 @@ import lombok.Builder;
 import org.jetbrains.annotations.Nullable;
 import tw.waterball.judgegirl.entities.problem.JudgePluginTag;
 
+import java.util.Collection;
 import java.util.Optional;
-import java.util.Set;
 
 @Builder
 public class PatchProblemParams {
@@ -16,7 +16,7 @@ public class PatchProblemParams {
     @Nullable
     private final JudgePluginTag matchPolicyPluginTag;
     @Nullable
-    private final Set<JudgePluginTag> filterPluginTags;
+    private final Collection<JudgePluginTag> filterPluginTags;
 
     public Optional<String> getTitle() {
         return Optional.ofNullable(title);
@@ -30,7 +30,7 @@ public class PatchProblemParams {
         return Optional.ofNullable(matchPolicyPluginTag);
     }
 
-    public Optional<Set<JudgePluginTag>> getFilterPluginTags() {
+    public Optional<Collection<JudgePluginTag>> getFilterPluginTags() {
         return Optional.ofNullable(filterPluginTags);
     }
 }

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/repositories/PatchProblemParams.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/repositories/PatchProblemParams.java
@@ -1,0 +1,36 @@
+package tw.waterball.judgegirl.problemservice.domain.repositories;
+
+import lombok.Builder;
+import org.jetbrains.annotations.Nullable;
+import tw.waterball.judgegirl.entities.problem.JudgePluginTag;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Builder
+public class PatchProblemParams {
+    @Nullable
+    private final String title;
+    @Nullable
+    private final String description;
+    @Nullable
+    private final JudgePluginTag matchPolicyPluginTag;
+    @Nullable
+    private final Set<JudgePluginTag> filterPluginTags;
+
+    public Optional<String> getTitle() {
+        return Optional.ofNullable(title);
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    public Optional<JudgePluginTag> getMatchPolicyPluginTag() {
+        return Optional.ofNullable(matchPolicyPluginTag);
+    }
+
+    public Optional<Set<JudgePluginTag>> getFilterPluginTags() {
+        return Optional.ofNullable(filterPluginTags);
+    }
+}

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/repositories/ProblemRepository.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/repositories/ProblemRepository.java
@@ -44,4 +44,8 @@ public interface ProblemRepository {
     Problem save(Problem problem, Map<LanguageEnv, InputStream> providedCodesZipMap, InputStream testcaseIOsZip);
 
     int saveProblemWithTitleAndGetId(String title);
+
+    void patchProblem(int problemId, PatchProblemParams params);
+
+    boolean problemExists(int problemId);
 }

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
@@ -7,8 +7,6 @@ import tw.waterball.judgegirl.problemservice.domain.repositories.PatchProblemPar
 import tw.waterball.judgegirl.problemservice.domain.repositories.ProblemRepository;
 
 import javax.inject.Named;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
 import static tw.waterball.judgegirl.commons.exceptions.NotFoundException.notFound;
@@ -41,12 +39,20 @@ public class PatchProblemUseCase extends BaseProblemUseCase {
         public JudgePluginTag judgePluginTag;
         public Set<JudgePluginTag> filterPluginTags;
 
-        public Request(int problemId, String title, String description, JudgePluginTag judgePluginTag, Collection<JudgePluginTag> filterPluginTags) {
+        public Request() {
+            problemId = 0;
+            title = null;
+            description = null;
+            judgePluginTag = null;
+            filterPluginTags = null;
+        }
+
+        public Request(int problemId, String title, String description, JudgePluginTag judgePluginTag, Set<JudgePluginTag> filterPluginTags) {
             this.problemId = problemId;
             this.title = title;
             this.description = description;
             this.judgePluginTag = judgePluginTag;
-            this.filterPluginTags = new HashSet<>(filterPluginTags);
+            this.filterPluginTags = filterPluginTags;
         }
     }
 }

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
@@ -9,6 +9,8 @@ import tw.waterball.judgegirl.problemservice.domain.repositories.ProblemReposito
 import javax.inject.Named;
 import java.util.Set;
 
+import static tw.waterball.judgegirl.commons.exceptions.NotFoundException.notFound;
+
 @Named
 public class PatchProblemUseCase extends BaseProblemUseCase {
     public PatchProblemUseCase(ProblemRepository problemRepository) {
@@ -24,9 +26,8 @@ public class PatchProblemUseCase extends BaseProblemUseCase {
                             .description(request.description)
                             .matchPolicyPluginTag(request.judgePluginTag)
                             .filterPluginTags(request.filterPluginTags).build());
-            return;
-        }
-        throw new NotFoundException(request.problemId, "problem");
+        } else
+            throw notFound("problem").id(request.problemId);
     }
 
     @Value

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
@@ -1,13 +1,15 @@
 package tw.waterball.judgegirl.problemservice.domain.usecases;
 
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import tw.waterball.judgegirl.commons.exceptions.NotFoundException;
 import tw.waterball.judgegirl.entities.problem.JudgePluginTag;
 import tw.waterball.judgegirl.problemservice.domain.repositories.PatchProblemParams;
 import tw.waterball.judgegirl.problemservice.domain.repositories.ProblemRepository;
 
 import javax.inject.Named;
-import java.util.Set;
+import java.util.Collection;
 
 import static tw.waterball.judgegirl.commons.exceptions.NotFoundException.notFound;
 
@@ -31,28 +33,15 @@ public class PatchProblemUseCase extends BaseProblemUseCase {
         }
     }
 
-    @Value
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Request {
-        public int problemId;
+        public static final int NOT_PRESENT = -1;
+        public int problemId = NOT_PRESENT;
         public String title;
         public String description;
         public JudgePluginTag judgePluginTag;
-        public Set<JudgePluginTag> filterPluginTags;
-
-        public Request() {
-            problemId = 0;
-            title = null;
-            description = null;
-            judgePluginTag = null;
-            filterPluginTags = null;
-        }
-
-        public Request(int problemId, String title, String description, JudgePluginTag judgePluginTag, Set<JudgePluginTag> filterPluginTags) {
-            this.problemId = problemId;
-            this.title = title;
-            this.description = description;
-            this.judgePluginTag = judgePluginTag;
-            this.filterPluginTags = filterPluginTags;
-        }
+        public Collection<JudgePluginTag> filterPluginTags;
     }
 }

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
@@ -7,6 +7,8 @@ import tw.waterball.judgegirl.problemservice.domain.repositories.PatchProblemPar
 import tw.waterball.judgegirl.problemservice.domain.repositories.ProblemRepository;
 
 import javax.inject.Named;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 import static tw.waterball.judgegirl.commons.exceptions.NotFoundException.notFound;
@@ -26,8 +28,9 @@ public class PatchProblemUseCase extends BaseProblemUseCase {
                             .description(request.description)
                             .matchPolicyPluginTag(request.judgePluginTag)
                             .filterPluginTags(request.filterPluginTags).build());
-        } else
+        } else {
             throw notFound("problem").id(request.problemId);
+        }
     }
 
     @Value
@@ -37,5 +40,13 @@ public class PatchProblemUseCase extends BaseProblemUseCase {
         public String description;
         public JudgePluginTag judgePluginTag;
         public Set<JudgePluginTag> filterPluginTags;
+
+        public Request(int problemId, String title, String description, JudgePluginTag judgePluginTag, Collection<JudgePluginTag> filterPluginTags) {
+            this.problemId = problemId;
+            this.title = title;
+            this.description = description;
+            this.judgePluginTag = judgePluginTag;
+            this.filterPluginTags = new HashSet<>(filterPluginTags);
+        }
     }
 }

--- a/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
+++ b/Problem-Service/src/main/java/tw/waterball/judgegirl/problemservice/domain/usecases/PatchProblemUseCase.java
@@ -1,0 +1,40 @@
+package tw.waterball.judgegirl.problemservice.domain.usecases;
+
+import lombok.Value;
+import tw.waterball.judgegirl.commons.exceptions.NotFoundException;
+import tw.waterball.judgegirl.entities.problem.JudgePluginTag;
+import tw.waterball.judgegirl.problemservice.domain.repositories.PatchProblemParams;
+import tw.waterball.judgegirl.problemservice.domain.repositories.ProblemRepository;
+
+import javax.inject.Named;
+import java.util.Set;
+
+@Named
+public class PatchProblemUseCase extends BaseProblemUseCase {
+    public PatchProblemUseCase(ProblemRepository problemRepository) {
+        super(problemRepository);
+    }
+
+    public void execute(Request request) throws NotFoundException {
+        if (problemRepository.problemExists(request.problemId)) {
+            problemRepository.patchProblem(
+                    request.problemId,
+                    PatchProblemParams.builder()
+                            .title(request.title)
+                            .description(request.description)
+                            .matchPolicyPluginTag(request.judgePluginTag)
+                            .filterPluginTags(request.filterPluginTags).build());
+            return;
+        }
+        throw new NotFoundException(request.problemId, "problem");
+    }
+
+    @Value
+    public static class Request {
+        public int problemId;
+        public String title;
+        public String description;
+        public JudgePluginTag judgePluginTag;
+        public Set<JudgePluginTag> filterPluginTags;
+    }
+}

--- a/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
@@ -19,7 +19,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tw.waterball.judgegirl.commons.models.files.FileResource;
-import tw.waterball.judgegirl.entities.problem.JudgePluginTag;
 import tw.waterball.judgegirl.entities.problem.Problem;
 import tw.waterball.judgegirl.entities.problem.Testcase;
 import tw.waterball.judgegirl.problemapi.views.ProblemItem;
@@ -29,7 +28,6 @@ import tw.waterball.judgegirl.problemservice.domain.usecases.*;
 import tw.waterball.judgegirl.springboot.utils.ResponseEntityUtils;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**

--- a/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
@@ -15,7 +15,6 @@ package tw.waterball.judgegirl.springboot.problem.controllers;
 
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tw.waterball.judgegirl.commons.models.files.FileResource;
@@ -104,8 +103,7 @@ public class ProblemController {
         return saveProblemWithTitleUseCase.execute(title);
     }
 
-    @PatchMapping(value = "/{problemId}",
-            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/{problemId}")
     public void patchProblem(@PathVariable int problemId,
                              @RequestBody PatchProblemUseCase.Request request) {
         patchProblemUseCase.execute(request);

--- a/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
@@ -15,9 +15,11 @@ package tw.waterball.judgegirl.springboot.problem.controllers;
 
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tw.waterball.judgegirl.commons.models.files.FileResource;
+import tw.waterball.judgegirl.entities.problem.JudgePluginTag;
 import tw.waterball.judgegirl.entities.problem.Problem;
 import tw.waterball.judgegirl.entities.problem.Testcase;
 import tw.waterball.judgegirl.problemapi.views.ProblemItem;
@@ -27,6 +29,7 @@ import tw.waterball.judgegirl.problemservice.domain.usecases.*;
 import tw.waterball.judgegirl.springboot.utils.ResponseEntityUtils;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -34,7 +37,7 @@ import java.util.stream.Collectors;
  */
 @CrossOrigin
 @RestController
-@RequestMapping(value = "/api/problems", method = {RequestMethod.GET, RequestMethod.POST})
+@RequestMapping(value = "/api/problems", method = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PATCH})
 @AllArgsConstructor
 public class ProblemController {
     private final GetProblemUseCase getProblemUseCase;
@@ -44,6 +47,8 @@ public class ProblemController {
     private final GetAllTagsUseCase getAllTagsUseCase;
     private final GetTestCasesUseCase getTestCasesUseCase;
     private final SaveProblemWithTitleUseCase saveProblemWithTitleUseCase;
+    private final PatchProblemUseCase patchProblemUseCase;
+
 
     @GetMapping("/tags")
     public List<String> getTags() {
@@ -101,6 +106,31 @@ public class ProblemController {
         return saveProblemWithTitleUseCase.execute(title);
     }
 
+    @PatchMapping(value = "/{problemId}/title",
+            consumes = MediaType.TEXT_PLAIN_VALUE)
+    public void patchProblemWithTitle(@PathVariable int problemId, @RequestBody String title) {
+        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, title, null, null, null));
+    }
+
+    @PatchMapping(value = "/{problemId}/description",
+            consumes = MediaType.TEXT_PLAIN_VALUE)
+    public void patchProblemWithDescription(@PathVariable int problemId, @RequestBody String description) {
+        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, null, description, null, null));
+    }
+
+    @PatchMapping(value = "/{problemId}/plugins/match",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public void patchProblemWithPluginMatchTags(@PathVariable int problemId,
+                                                @RequestBody JudgePluginTag judgePluginTag) {
+        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, null, null, judgePluginTag, null));
+    }
+
+    @PatchMapping(value = "/{problemId}/plugins/filter",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public void patchProblemWithPluginFilterTags(@PathVariable int problemId,
+                                                 @RequestBody Set<JudgePluginTag> judgePluginTagSet) {
+        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, null, null, null, judgePluginTagSet));
+    }
 }
 
 class GetProblemPresenter implements GetProblemUseCase.Presenter {

--- a/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemController.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  */
 @CrossOrigin
 @RestController
-@RequestMapping(value = "/api/problems", method = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PATCH})
+@RequestMapping(value = "/api/problems")
 @AllArgsConstructor
 public class ProblemController {
     private final GetProblemUseCase getProblemUseCase;
@@ -106,30 +106,11 @@ public class ProblemController {
         return saveProblemWithTitleUseCase.execute(title);
     }
 
-    @PatchMapping(value = "/{problemId}/title",
-            consumes = MediaType.TEXT_PLAIN_VALUE)
-    public void patchProblemWithTitle(@PathVariable int problemId, @RequestBody String title) {
-        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, title, null, null, null));
-    }
-
-    @PatchMapping(value = "/{problemId}/description",
-            consumes = MediaType.TEXT_PLAIN_VALUE)
-    public void patchProblemWithDescription(@PathVariable int problemId, @RequestBody String description) {
-        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, null, description, null, null));
-    }
-
-    @PatchMapping(value = "/{problemId}/plugins/match",
+    @PatchMapping(value = "/{problemId}",
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    public void patchProblemWithPluginMatchTags(@PathVariable int problemId,
-                                                @RequestBody JudgePluginTag judgePluginTag) {
-        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, null, null, judgePluginTag, null));
-    }
-
-    @PatchMapping(value = "/{problemId}/plugins/filter",
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    public void patchProblemWithPluginFilterTags(@PathVariable int problemId,
-                                                 @RequestBody Set<JudgePluginTag> judgePluginTagSet) {
-        patchProblemUseCase.execute(new PatchProblemUseCase.Request(problemId, null, null, null, judgePluginTagSet));
+    public void patchProblem(@PathVariable int problemId,
+                             @RequestBody PatchProblemUseCase.Request request) {
+        patchProblemUseCase.execute(request);
     }
 }
 

--- a/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/repositories/MongoProblemRepository.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/repositories/MongoProblemRepository.java
@@ -13,7 +13,6 @@
 
 package tw.waterball.judgegirl.springboot.problem.repositories;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -53,12 +52,10 @@ public class MongoProblemRepository implements ProblemRepository {
     private final static int OFFSET_NEW_PROBLEM_ID = 70000;
     private final MongoTemplate mongoTemplate;
     private final GridFsTemplate gridFsTemplate;
-    private final ObjectMapper objectMapper;
 
     public MongoProblemRepository(MongoTemplate mongoTemplate, GridFsTemplate gridFsTemplate) {
         this.mongoTemplate = mongoTemplate;
         this.gridFsTemplate = gridFsTemplate;
-        this.objectMapper = new ObjectMapper();
     }
 
     @Override
@@ -143,12 +140,8 @@ public class MongoProblemRepository implements ProblemRepository {
         Query query = new Query(where("_id").is(problemId));
         params.getTitle().ifPresent(title -> update.set("title", title));
         params.getDescription().ifPresent(des -> update.set("description", des));
-        params.getMatchPolicyPluginTag().ifPresent(tag -> {
-            update.set("outputMatchPolicyPluginTag.type", tag.getType())
-                    .set("outputMatchPolicyPluginTag.group", tag.getGroup())
-                    .set("outputMatchPolicyPluginTag.name", tag.getName())
-                    .set("outputMatchPolicyPluginTag.version", tag.getVersion());
-        });
+        params.getMatchPolicyPluginTag().ifPresent(tag ->
+                update.set("outputMatchPolicyPluginTag", tag));
         params.getFilterPluginTags().ifPresent(tags -> {
             if (!tags.isEmpty()) {
                 update.addToSet("filterPluginTags").each(tags);

--- a/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/repositories/MongoProblemRepository.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/main/java/tw/waterball/judgegirl/springboot/problem/repositories/MongoProblemRepository.java
@@ -140,13 +140,8 @@ public class MongoProblemRepository implements ProblemRepository {
         Query query = new Query(where("_id").is(problemId));
         params.getTitle().ifPresent(title -> update.set("title", title));
         params.getDescription().ifPresent(des -> update.set("description", des));
-        params.getMatchPolicyPluginTag().ifPresent(tag ->
-                update.set("outputMatchPolicyPluginTag", tag));
-        params.getFilterPluginTags().ifPresent(tags -> {
-            if (!tags.isEmpty()) {
-                update.addToSet("filterPluginTags").each(tags);
-            }
-        });
+        params.getMatchPolicyPluginTag().ifPresent(tag -> update.set("outputMatchPolicyPluginTag", tag));
+        params.getFilterPluginTags().ifPresent(tags -> update.set("filterPluginTags", tags));
         mongoTemplate.updateFirst(query, update, Problem.class);
     }
 

--- a/Spring-Boot/Spring-Boot-Problem/src/test/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemControllerTest.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/test/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemControllerTest.java
@@ -32,6 +32,7 @@ import tw.waterball.judgegirl.entities.stubs.ProblemStubs;
 import tw.waterball.judgegirl.problemapi.views.ProblemItem;
 import tw.waterball.judgegirl.problemapi.views.ProblemView;
 import tw.waterball.judgegirl.problemservice.domain.repositories.ProblemRepository;
+import tw.waterball.judgegirl.problemservice.domain.usecases.PatchProblemUseCase;
 import tw.waterball.judgegirl.springboot.problem.SpringBootProblemApplication;
 import tw.waterball.judgegirl.springboot.problem.repositories.MongoProblemRepository;
 import tw.waterball.judgegirl.springboot.profiles.Profiles;
@@ -268,9 +269,13 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
     void GivenOneProblemSavedAndPatchProblemWithTitle_WhenQueryById_ShouldHaveNewTitle() throws Exception {
         Problem savedProblem = givenProblemsSaved(1).get(0);
         String newTitle = UUID.randomUUID().toString();
+
+        PatchProblemUseCase.Request request = new PatchProblemUseCase.Request();
+        patchProblem(savedProblem.getId(), PatchProblemUseCase.Request);
         mockMvc.perform(patch("/api/problems/{problemId}/title", savedProblem.getId())
                 .contentType(MediaType.TEXT_PLAIN_VALUE).content(newTitle))
                 .andExpect(status().isOk());
+
         Problem queryProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
         assertNotNull(queryProblem);
         assertEquals(newTitle, queryProblem.getTitle());
@@ -331,6 +336,13 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
         assertEquals(
                 objectMapper.writeValueAsString(pluginFilterTags),
                 objectMapper.writeValueAsString(queryPluginFilterTags));
+    }
+
+    private void patchProblem(int problemId, PatchProblemUseCase.Request request) throws Exception {
+        mockMvc.perform(patch("/api/problems/{problemId}", request)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
     }
 
 }

--- a/Spring-Boot/Spring-Boot-Problem/src/test/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemControllerTest.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/test/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemControllerTest.java
@@ -267,33 +267,33 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
 
     @Test
     void GivenOneProblemSavedAndPatchProblemWithNewTitle_WhenQueryTheSameProblem_ShouldHaveNewTitle() throws Exception {
-        Problem savedProblem = givenProblemsSaved(1).get(0);
+        Problem savedProblem = givenOneProblemSaved();
         String newTitle = UUID.randomUUID().toString();
 
         savedProblem.setTitle(newTitle);
         patchProblem(savedProblem);
 
-        Problem queryProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
-        assertNotNull(queryProblem);
-        assertEquals(newTitle, queryProblem.getTitle());
+        Problem actualProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
+        assertNotNull(actualProblem);
+        assertEquals(newTitle, actualProblem.getTitle());
     }
 
     @Test
     void GivenOneProblemSavedAndPatchProblemWithDescription_WhenQueryById_ShouldHaveNewDescription() throws Exception {
-        Problem savedProblem = givenProblemsSaved(1).get(0);
+        Problem savedProblem = givenOneProblemSaved();
         String newDescription = UUID.randomUUID().toString();
 
         savedProblem.setDescription(newDescription);
         patchProblem(savedProblem);
 
-        Problem queryProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
-        assertNotNull(queryProblem);
-        assertEquals(newDescription, queryProblem.getDescription());
+        Problem actualProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
+        assertNotNull(actualProblem);
+        assertEquals(newDescription, actualProblem.getDescription());
     }
 
     @Test
     void GivenOneProblemSavedAndPatchProblemWithPluginMatchTags_WhenQueryById_ShouldHaveNewTags() throws Exception {
-        Problem savedProblem = givenProblemsSaved(1).get(0);
+        Problem savedProblem = givenOneProblemSaved();
         JudgePluginTag pluginMatchTag = new JudgePluginTag();
         pluginMatchTag.setGroup("Judge Girl");
         pluginMatchTag.setName("Test");
@@ -303,15 +303,15 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
         savedProblem.setOutputMatchPolicyPluginTag(pluginMatchTag);
         patchProblem(savedProblem);
 
-        Problem queryProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
-        assertNotNull(queryProblem);
-        JudgePluginTag queryPluginMatchTag = queryProblem.getOutputMatchPolicyPluginTag();
-        assertEquals(pluginMatchTag, queryPluginMatchTag);
+        Problem actualProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
+        assertNotNull(actualProblem);
+        JudgePluginTag actualPluginMatchTag = actualProblem.getOutputMatchPolicyPluginTag();
+        assertEquals(pluginMatchTag, actualPluginMatchTag);
     }
 
     @Test
     void GivenOneProblemSavedAndPatchProblemWithPluginFilterTags_WhenQueryById_ShouldHaveNewTags() throws Exception {
-        Problem savedProblem = givenProblemsSaved(1).get(0);
+        Problem savedProblem = givenOneProblemSaved();
         Set<JudgePluginTag> filterPluginTags = new HashSet<>();
         final int COUNT_FILTER = 10;
         for (int i = 1; i <= COUNT_FILTER; ++i) {
@@ -326,9 +326,9 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
         savedProblem.setFilterPluginTags(filterPluginTags);
         patchProblem(savedProblem);
 
-        Problem queryProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
-        assertNotNull(queryProblem);
-        Set<JudgePluginTag> queryPluginFilterTags = new HashSet<>(queryProblem.getFilterPluginTags());
+        Problem actualProblem = mongoTemplate.findById(savedProblem.getId(), Problem.class);
+        assertNotNull(actualProblem);
+        Set<JudgePluginTag> queryPluginFilterTags = new HashSet<>(actualProblem.getFilterPluginTags());
         assertEquals(queryPluginFilterTags, filterPluginTags);
     }
 
@@ -343,6 +343,10 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
                                 problem.getOutputMatchPolicyPluginTag(),
                                 new HashSet<>(problem.getFilterPluginTags())))))
                 .andExpect(status().isOk());
+    }
+
+    private Problem givenOneProblemSaved() {
+        return givenProblemsSaved(1).get(0);
     }
 }
 

--- a/Spring-Boot/Spring-Boot-Problem/src/test/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemControllerTest.java
+++ b/Spring-Boot/Spring-Boot-Problem/src/test/java/tw/waterball/judgegirl/springboot/problem/controllers/ProblemControllerTest.java
@@ -341,7 +341,7 @@ public class ProblemControllerTest extends AbstractSpringBootTest {
                                 problem.getTitle(),
                                 problem.getDescription(),
                                 problem.getOutputMatchPolicyPluginTag(),
-                                problem.getFilterPluginTags()))))
+                                new HashSet<>(problem.getFilterPluginTags())))))
                 .andExpect(status().isOk());
     }
 }

--- a/Spring-Boot/Spring-Boot-Student/src/test/resources/test.properties
+++ b/Spring-Boot/Spring-Boot-Student/src/test/resources/test.properties
@@ -1,3 +1,0 @@
-test.student-id= 1434
-test.account= dev00
-test.password= aabbabc

--- a/Spring-Boot/Spring-Boot-Student/src/test/resources/test.properties
+++ b/Spring-Boot/Spring-Boot-Student/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+test.student-id= 1434
+test.account= dev00
+test.password= aabbabc


### PR DESCRIPTION
Issue: #111 

# Description

Added:
 - Method `ProblemRepository::patchProblem(int, PatchProblemParams)`.
 - Class `PatchProblemParams`: used by `ProblemRepository::patchProblem(int, PatchProblemParams)`.
 - Method `ProblemRepository::problemExists(int problemId) -> boolean`
     - The Ideas: `ProblemRepository::findProblemById(int) -> Optional<Problem>` called by `BaseProblemUseCase::doFindProblemById` will need to transfer entire Problem, which is time-consuming when Problem is large. This method instead check whether a Problem with `problemId` exist by `MongoTemplate::exists` to resolve this performance issue.
     - Reference: https://stackoverflow.com/a/22278847/5290519
 - Tests: added 4 testcases for patch title / description / matchPluginTag / fitlerPluginTags, independently.
    