### PR TITLE
Submission Save Strategy: Verdict shortcut / Copy-On-Write

### DIFF
--- a/Commons/src/main/java/tw/waterball/judgegirl/commons/models/files/StreamingResource.java
+++ b/Commons/src/main/java/tw/waterball/judgegirl/commons/models/files/StreamingResource.java
@@ -35,8 +35,12 @@ public class StreamingResource implements Closeable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         StreamingResource that = (StreamingResource) o;
         try {
             //TODO: `contentEquals` will consume and exhaust the stream,

--- a/Commons/src/main/java/tw/waterball/judgegirl/commons/utils/StreamUtils.java
+++ b/Commons/src/main/java/tw/waterball/judgegirl/commons/utils/StreamUtils.java
@@ -14,13 +14,13 @@
 package tw.waterball.judgegirl.commons.utils;
 
 import tw.waterball.judgegirl.commons.utils.functional.ErrConsumer;
+import tw.waterball.judgegirl.commons.utils.functional.ErrFunction;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -29,8 +29,14 @@ import java.util.stream.IntStream;
  * @author - johnny850807@gmail.com (Waterball)
  */
 public abstract class StreamUtils {
-    public static <T, R> List<T> mapToList(Collection<R> collection, Function<R, T> mapping) {
-        return collection.stream().map(mapping).collect(Collectors.toList());
+    public static <T, R> List<T> mapToList(Collection<R> collection, ErrFunction<R, T> mapping) {
+        return collection.stream().map(in -> {
+            try {
+                return mapping.apply(in);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.toList());
     }
 
     public static <T, L, R> List<T> zipToList(List<L> left, List<R> right,

--- a/Commons/src/main/java/tw/waterball/judgegirl/commons/utils/functional/ErrFunction.java
+++ b/Commons/src/main/java/tw/waterball/judgegirl/commons/utils/functional/ErrFunction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Johnny850807 (Waterball) 潘冠辰
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package tw.waterball.judgegirl.commons.utils.functional;
+
+/**
+ * @author - johnny850807@gmail.com (Waterball)
+ */
+@FunctionalInterface
+public interface ErrFunction<T, R> {
+    R apply(T var1) throws Exception;
+}

--- a/Entities/src/main/java/tw/waterball/judgegirl/entities/submission/Submission.java
+++ b/Entities/src/main/java/tw/waterball/judgegirl/entities/submission/Submission.java
@@ -45,15 +45,16 @@ public class Submission implements Comparable<Submission> {
         this.submissionTime = submissionTime;
     }
 
-    public Submission(String id, int studentId, int problemId, String languageEnvName, String submittedCodesFileId) {
-        this.id = id;
-        this.studentId = studentId;
-        this.problemId = problemId;
-        this.languageEnvName = languageEnvName;
-        this.submittedCodesFileId = submittedCodesFileId;
+    public Submission(int studentId, int problemId, String languageEnvName) {
+        this(studentId, problemId, languageEnvName, null);
     }
 
     public Submission(int studentId, int problemId, String languageEnvName, String submittedCodesFileId) {
+        this(null, studentId, problemId, languageEnvName, submittedCodesFileId);
+    }
+
+    public Submission(String id, int studentId, int problemId, String languageEnvName, String submittedCodesFileId) {
+        this.id = id;
         this.studentId = studentId;
         this.problemId = problemId;
         this.languageEnvName = languageEnvName;

--- a/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/controllers/SubmissionController.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/controllers/SubmissionController.java
@@ -29,7 +29,6 @@ import tw.waterball.judgegirl.submissionapi.views.SubmissionView;
 import tw.waterball.judgegirl.submissionservice.domain.usecases.*;
 import tw.waterball.judgegirl.submissionservice.domain.usecases.dto.SubmissionQueryParams;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -63,15 +62,11 @@ public class SubmissionController {
                           @PathVariable int studentId,
                           @RequestParam(SUBMIT_CODE_MULTIPART_KEY_NAME) MultipartFile[] submittedCodes) {
         return validateIdentity(studentId, bearerToken, (token) -> {
-            try {
-                boolean throttling = !token.isAdmin();
-                SubmitCodeRequest request = convertToSubmitCodeRequest(problemId, langEnvName, studentId, submittedCodes, throttling);
-                SubmissionPresenter presenter = new SubmissionPresenter();
-                submitCodeUseCase.execute(request, presenter);
-                return ResponseEntity.accepted().body(presenter.present());
-            } catch (IOException e) {
-                throw new RuntimeException("File uploading error", e);
-            }
+            boolean throttling = !token.isAdmin();
+            SubmitCodeRequest request = convertToSubmitCodeRequest(problemId, langEnvName, studentId, submittedCodes, throttling);
+            SubmissionPresenter presenter = new SubmissionPresenter();
+            submitCodeUseCase.execute(request, presenter);
+            return ResponseEntity.accepted().body(presenter.present());
         });
     }
 

--- a/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/data/SubmissionData.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/data/SubmissionData.java
@@ -37,4 +37,16 @@ public class SubmissionData {
     private VerdictData verdict;
     private String submittedCodesFileId;
     private Date submissionTime;
+    private String submittedCodesHash;
+
+
+    public SubmissionData(String id, int problemId, String languageEnvName, int studentId, VerdictData verdict, String submittedCodesFileId, Date submissionTime) {
+        this.id = id;
+        this.problemId = problemId;
+        this.languageEnvName = languageEnvName;
+        this.studentId = studentId;
+        this.verdict = verdict;
+        this.submittedCodesFileId = submittedCodesFileId;
+        this.submissionTime = submissionTime;
+    }
 }

--- a/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/strategy/DuplicateDetectionCopyOnWrite.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/strategy/DuplicateDetectionCopyOnWrite.java
@@ -1,0 +1,90 @@
+package tw.waterball.judgegirl.springboot.submission.impl.mongo.strategy;
+
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import tw.waterball.judgegirl.commons.models.files.FileResource;
+import tw.waterball.judgegirl.commons.models.files.StreamingResource;
+import tw.waterball.judgegirl.entities.submission.Submission;
+import tw.waterball.judgegirl.springboot.submission.impl.mongo.data.SubmissionData;
+
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.IntStream.range;
+import static javax.xml.bind.DatatypeConverter.printHexBinary;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static tw.waterball.judgegirl.commons.utils.StreamUtils.mapToList;
+import static tw.waterball.judgegirl.commons.utils.ZipUtils.zipToStream;
+import static tw.waterball.judgegirl.springboot.submission.impl.mongo.data.DataMapper.toData;
+import static tw.waterball.judgegirl.springboot.submission.impl.mongo.data.DataMapper.toEntity;
+
+/**
+ * @author - johnny850807@gmail.com (Waterball)
+ */
+@ConditionalOnProperty(name = "judge-girl.submission-service.save-strategy",
+        havingValue = DuplicateDetectionCopyOnWrite.STRATEGY_NAME)
+@AllArgsConstructor
+public class DuplicateDetectionCopyOnWrite implements SaveSubmissionWithCodesStrategy {
+    public final static String STRATEGY_NAME = "copy-on-write";
+    protected final MongoTemplate mongoTemplate;
+    protected final GridFsTemplate gridFsTemplate;
+
+    @Override
+    public Submission perform(Submission submission, List<FileResource> originalCodes, String fileName) {
+        final SubmissionData data = toData(submission);
+        var zip = new StreamingResource(fileName, zipAndComputeHash(data, originalCodes));
+        detectDuplicateSubmissionData(data)
+                .ifPresentOrElse(duplicate -> copyOnWrite(data, duplicate),
+                        () -> data.setSubmittedCodesFileId(saveAndGetFileId(zip)));
+        return toEntity(mongoTemplate.save(data));
+    }
+
+    @SneakyThrows
+    public InputStream zipAndComputeHash(SubmissionData data, List<FileResource> codes) {
+        var digestInputStreams = mapToList(codes,
+                code -> new DigestInputStream(code.getInputStream(), MessageDigest.getInstance("MD5")));
+        range(0, codes.size()).forEach(i -> codes.get(i).setInputStream(digestInputStreams.get(i)));
+        InputStream zip = zipToStream(codes);
+        data.setSubmittedCodesHash(hash(digestInputStreams));
+        return zip;
+    }
+
+    private String hash(List<DigestInputStream> digestInputStreams) {
+        return digestInputStreams.stream().map(this::digestToHex)
+                .reduce((prev, current) -> prev + "|" + current).orElse("");
+    }
+
+    private Optional<SubmissionData> detectDuplicateSubmissionData(SubmissionData data) {
+        return ofNullable(mongoTemplate.findOne(Query.query(
+                where("submittedCodesHash").is(data.getSubmittedCodesHash())
+                        .and("problemId").is(data.getProblemId())
+                        .and("verdict").exists(true)), SubmissionData.class));
+    }
+
+    private void copyOnWrite(SubmissionData data, SubmissionData duplicate) {
+        // copy on write --> directly associate to the same file's id in GridFs
+        data.setSubmittedCodesFileId(duplicate.getSubmittedCodesFileId());
+        onDuplicate(data, duplicate);
+    }
+
+    private String digestToHex(DigestInputStream digestInputStream) {
+        return printHexBinary(digestInputStream.getMessageDigest().digest()).toUpperCase();
+    }
+
+    private String saveAndGetFileId(StreamingResource streamingResource) {
+        return gridFsTemplate.store(streamingResource.getInputStream(),
+                streamingResource.getFileName()).toString();
+    }
+
+    protected void onDuplicate(SubmissionData newData, SubmissionData duplicateData) {
+        // hook
+    }
+}

--- a/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/strategy/SaveSubmissionWithCodesStrategy.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/strategy/SaveSubmissionWithCodesStrategy.java
@@ -1,0 +1,13 @@
+package tw.waterball.judgegirl.springboot.submission.impl.mongo.strategy;
+
+import tw.waterball.judgegirl.commons.models.files.FileResource;
+import tw.waterball.judgegirl.entities.submission.Submission;
+
+import java.util.List;
+
+/**
+ * @author - johnny850807@gmail.com (Waterball)
+ */
+public interface SaveSubmissionWithCodesStrategy {
+    Submission perform(Submission submission, List<FileResource> originalCodes, String fileName);
+}

--- a/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/strategy/VerdictShortcut.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/main/java/tw/waterball/judgegirl/springboot/submission/impl/mongo/strategy/VerdictShortcut.java
@@ -1,0 +1,27 @@
+package tw.waterball.judgegirl.springboot.submission.impl.mongo.strategy;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import org.springframework.stereotype.Component;
+import tw.waterball.judgegirl.springboot.submission.impl.mongo.data.SubmissionData;
+
+/**
+ * @author - johnny850807@gmail.com (Waterball)
+ */
+
+@ConditionalOnProperty(name = "judge-girl.submission-service.save-strategy",
+        havingValue = VerdictShortcut.STRATEGY_NAME)
+@Component
+public class VerdictShortcut extends DuplicateDetectionCopyOnWrite {
+    public final static String STRATEGY_NAME = "verdict-shortcut";
+
+    public VerdictShortcut(MongoTemplate mongoTemplate, GridFsTemplate gridFsTemplate) {
+        super(mongoTemplate, gridFsTemplate);
+    }
+
+    @Override
+    protected void onDuplicate(SubmissionData newData, SubmissionData duplicateData) {
+        newData.setVerdict(duplicateData.getVerdict());  // verdict shortcut
+    }
+}

--- a/Spring-Boot/Spring-Boot-Submission/src/test/java/learning/DigestInputStreamTest.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/test/java/learning/DigestInputStreamTest.java
@@ -1,0 +1,41 @@
+package learning;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static javax.xml.bind.DatatypeConverter.printHexBinary;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Learn by testing.
+ *
+ * @author - johnny850807@gmail.com (Waterball)
+ */
+public class DigestInputStreamTest {
+    @Test
+    void twoDifferentBytesShouldHaveDifferentHash() throws NoSuchAlgorithmException, IOException {
+        byte[] a = "int plus(int a, int b) {return a + b;}".getBytes();
+        byte[] b = "int minus(int a, int b) {return a - b;}".getBytes();
+        var d1 = new DigestInputStream(new ByteArrayInputStream(a), MessageDigest.getInstance("MD5"));
+        var d2 = new DigestInputStream(new ByteArrayInputStream(b), MessageDigest.getInstance("MD5"));
+        IOUtils.toByteArray(d1);  // consume
+        IOUtils.toByteArray(d2);
+
+        byte[] digest1 = d1.getMessageDigest().digest();
+        byte[] digest2 = d2.getMessageDigest().digest();
+        assertThat(digest1, not(equalTo(digest2)));
+
+        String hex1 = printHexBinary(digest1);
+        String hex2 = printHexBinary(digest2);
+        assertNotEquals(hex1, hex2);
+    }
+}

--- a/Spring-Boot/Spring-Boot-Submission/src/test/java/tw/waterball/judgegirl/springboot/submission/controllers/SubmissionQueryControllerTest.java
+++ b/Spring-Boot/Spring-Boot-Submission/src/test/java/tw/waterball/judgegirl/springboot/submission/controllers/SubmissionQueryControllerTest.java
@@ -1,3 +1,5 @@
+package tw.waterball.judgegirl.springboot.submission.controllers;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;

--- a/Submission-Service/src/main/java/tw/waterball/judgegirl/submissionservice/domain/repositories/SubmissionRepository.java
+++ b/Submission-Service/src/main/java/tw/waterball/judgegirl/submissionservice/domain/repositories/SubmissionRepository.java
@@ -43,6 +43,8 @@ public interface SubmissionRepository {
 
     Submission save(Submission submission);
 
+    Submission saveSubmissionWithCodes(Submission submission, List<FileResource> originalCodes) throws IOException;
+
     String saveZippedSubmittedCodesAndGetFileId(StreamingResource streamingResource) throws IOException;
 
     Optional<FileResource> downloadZippedSubmittedCodes(String submissionId);

--- a/Submission-Service/src/main/java/tw/waterball/judgegirl/submissionservice/domain/usecases/SubmitCodeUseCase.java
+++ b/Submission-Service/src/main/java/tw/waterball/judgegirl/submissionservice/domain/usecases/SubmitCodeUseCase.java
@@ -14,50 +14,48 @@
 package tw.waterball.judgegirl.submissionservice.domain.usecases;
 
 import lombok.AllArgsConstructor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import tw.waterball.judgegirl.commons.models.files.StreamingResource;
-import tw.waterball.judgegirl.commons.utils.ZipUtils;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import tw.waterball.judgegirl.commons.models.files.FileResource;
 import tw.waterball.judgegirl.entities.problem.Problem;
 import tw.waterball.judgegirl.entities.submission.Submission;
 import tw.waterball.judgegirl.problemapi.clients.ProblemServiceDriver;
 import tw.waterball.judgegirl.problemapi.views.ProblemView;
 import tw.waterball.judgegirl.submissionservice.deployer.JudgerDeployer;
 import tw.waterball.judgegirl.submissionservice.domain.repositories.SubmissionRepository;
+import tw.waterball.judgegirl.submissionservice.domain.usecases.exceptions.SubmissionThrottlingException;
 
 import javax.inject.Named;
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.List;
 
 /**
  * @author - johnny850807@gmail.com (Waterball)
  */
+@Slf4j
 @Named
 @AllArgsConstructor
 public class SubmitCodeUseCase {
-    private final static Logger logger = LogManager.getLogger(SubmitCodeUseCase.class);
     private final ThrottleSubmissionUseCase throttleSubmissionUseCase;
     private final SubmissionRepository submissionRepository;
     private final JudgerDeployer judgerDeployer;
     private final ProblemServiceDriver problemServiceDriver;
 
-    public void execute(SubmitCodeRequest request, SubmissionPresenter presenter) throws IOException {
-        logger.info(request);
+    public void execute(SubmitCodeRequest request, SubmissionPresenter presenter) throws SubmissionThrottlingException {
+        mayThrottleOnRequest(request);
+
+        Problem problem = getProblem(request.problemId);
+        Submission submission = new Submission(request.studentId, problem.getId(), request.languageEnvName);
+        submission = save(submission, request.fileResources);
+
+        mayDeployJudgerIfNotJudged(request, problem, submission);
+        presenter.setSubmission(submission);
+    }
+
+    private void mayThrottleOnRequest(SubmitCodeRequest request) throws SubmissionThrottlingException {
+        log.info(request.toString());
         if (request.throttle) {
             throttleSubmissionUseCase.execute(request);
         }
-
-        String submittedCodeFileId = zipAndSaveSubmittedCodesAndGetFileId(request);
-        Problem problem = getProblem(request.problemId);
-        Submission submission = new Submission(request.studentId, request.problemId, request.languageEnvName, submittedCodeFileId);
-        submission.setProblemId(problem.getId());
-
-        submission = submissionRepository.save(submission);
-        logger.info("Saved submission: " + submission.getId());
-
-        judgerDeployer.deployJudger(problem, request.getStudentId(), submission);
-        logger.info("Completed: " + request);
-        presenter.setSubmission(submission);
     }
 
     private Problem getProblem(int problemId) {
@@ -65,13 +63,19 @@ public class SubmitCodeUseCase {
         return ProblemView.toEntity(problemView);
     }
 
-    private String zipAndSaveSubmittedCodesAndGetFileId(SubmitCodeRequest request) throws IOException {
-        // TODO: refactor, the data-storing related code should be encapsulated in the repository
-        String fileName = String.format("%d-%s-%d.zip", request.studentId, request.problemId,
-                System.currentTimeMillis());
-        InputStream zippedSubmittedCodesStream = ZipUtils.zipToStream(request.getFileResources());
-        StreamingResource streamingResource = new StreamingResource(fileName, zippedSubmittedCodesStream);
-        return submissionRepository.saveZippedSubmittedCodesAndGetFileId(streamingResource);
+    @SneakyThrows
+    private Submission save(Submission submission, List<FileResource> codes) {
+        Submission saved = submissionRepository.saveSubmissionWithCodes(submission, codes);
+        log.info("Saved submission: " + submission.getId());
+        return saved;
     }
+
+    private void mayDeployJudgerIfNotJudged(SubmitCodeRequest request, Problem problem, Submission submission) {
+        if (!submission.isJudged()) {
+            judgerDeployer.deployJudger(problem, request.getStudentId(), submission);
+        }
+        log.info("Completed: {}", request);
+    }
+
 
 }

--- a/Submission-Service/src/main/java/tw/waterball/judgegirl/submissionservice/domain/usecases/ThrottleSubmissionUseCase.java
+++ b/Submission-Service/src/main/java/tw/waterball/judgegirl/submissionservice/domain/usecases/ThrottleSubmissionUseCase.java
@@ -32,7 +32,7 @@ public class ThrottleSubmissionUseCase {
         this.submissionRepository = submissionRepository;
     }
 
-    public void execute(SubmitCodeRequest request) {
+    public void execute(SubmitCodeRequest request) throws SubmissionThrottlingException {
         SubmissionThrottling throttling = submissionRepository.findSubmissionThrottling(
                 request.getProblemId(), request.getStudentId())
                 .orElse(new SubmissionThrottling(request.problemId, request.studentId, 0L));


### PR DESCRIPTION
Submission Save Strategy: Verdict shortcut / Copy-On-Write

- Copy-On-Write:
    - if there are submissions that have the same  `codes hash` share the file id (GridFs)
- Verdict-Shortcut
    - if there are submissions that have the same `codes hash` also share the verdict (no judger deployed)

see `DuplicateDetectionCopyOnWrite` for details

https://user-images.githubusercontent.com/23109467/113554685-45e07f00-962c-11eb-8bcc-98db3846fa12.mp4

